### PR TITLE
fix(js): corrige caminhos relativos para o deploy (erro 404)

### DIFF
--- a/js/modules.min/doaocoesModule.min.js
+++ b/js/modules.min/doaocoesModule.min.js
@@ -4,5 +4,5 @@ if(el.innerText==='R$100')return valorNoDiplay(el.innerText)
 if(el.innerText==='Desejo doar esse valor')return criaPagamento()});displayMostraValor.addEventListener('keypress',e=>{Form.removeElementos('.saibaMaisExibido');if(e.keyCode===13){e.preventDefault();criaPagamento()}})}
 const valorNoDiplay=(valor)=>{Form.removeElementos('.saibaMaisExibido');const valorFormatado=valor.replace('R$','');displayMostraValor.value=valorFormatado}
 const criaPagamento=()=>{Form.removeElementos('.imagens-js');Form.removeElementos('.saibaMaisExibido');if(!displayMostraValor.value)return displayMostraValor.after(SaibaMais.criaParagrafo({msg:'Adicione um valor',cor:'red'}))
-const divPagamento=document.querySelector('.div-formaDePagamento');divPagamento.appendChild(criaTagImg({endereco:'../../img/qrCode.png',largura:'50%',altura:'40%'}))}
+const divPagamento=document.querySelector('.div-formaDePagamento');divPagamento.appendChild(criaTagImg({endereco:'./img/qrCode.png',largura:'50%',altura:'40%'}))}
 const criaTagImg=({endereco,largura,altura})=>{const img=document.createElement('img');img.setAttribute('src',endereco);img.style.width=largura;img.style.height=altura;img.classList.add('imagens-js');return img}

--- a/js/modules.min/saibamaisModule.min.js
+++ b/js/modules.min/saibamaisModule.min.js
@@ -1,7 +1,7 @@
 import Form from './validaformModule.min.js';export function saibaMais(){const usaClass=new SaibaMais();usaClass.formataJson();addEventListener('click',e=>{const el=e.target;if(!el.classList.contains('saiba-mais'))return
 usaClass.inicia(el);})}
 export class SaibaMais{constructor(){this.botao;this.conteudos=[]}
-inicia(botao){this.botao=botao;this.botaoApertado()};async formataJson(){try{const json=await fetch('../../assets/data/projetos.json');const jsonFormatado=await json.json()
+inicia(botao){this.botao=botao;this.botaoApertado()};async formataJson(){try{const json=await fetch('./assets/data/projetos.json');const jsonFormatado=await json.json()
 jsonFormatado.projetosVoluntariado.forEach(conteudo=>{this.conteudos.push(conteudo)})}catch(e){new console.error(e)}}
 botaoApertado(){if(this.botao.classList.contains('PresevarVegetação'))return this.exibirConteudo(1)
 if(this.botao.classList.contains('viveiroComunitario'))return this.exibirConteudo(2)

--- a/js/modules/doaocoesModule.js
+++ b/js/modules/doaocoesModule.js
@@ -31,7 +31,7 @@ const criaPagamento = () => {
     Form.removeElementos('.saibaMaisExibido');
     if(!displayMostraValor.value) return displayMostraValor.after(SaibaMais.criaParagrafo({ msg: 'Adicione um valor', cor: 'red'}))
     const divPagamento = document.querySelector('.div-formaDePagamento');
-    divPagamento.appendChild(criaTagImg({ endereco: '../../img/qrCode.png', largura:'50%', altura:'40%'}));
+    divPagamento.appendChild(criaTagImg({ endereco: './img/qrCode.png', largura:'50%', altura:'40%'}));
 }
 
 const criaTagImg = ({ endereco, largura, altura }) => {

--- a/js/modules/saibamaisModule.js
+++ b/js/modules/saibamaisModule.js
@@ -24,7 +24,7 @@ export class SaibaMais {
 
     async formataJson () {
         try {
-            const json = await fetch('../../assets/data/projetos.json');
+            const json = await fetch('./assets/data/projetos.json');
             const jsonFormatado = await json.json()
             jsonFormatado.projetosVoluntariado.forEach(conteudo => {
                 this.conteudos.push(conteudo);


### PR DESCRIPTION
Este PR corrige um bug crítico que causava erros 404 no site em produção (GitHub Pages).

**Problema:**
O `fetch` do `projetos.json` (no `saibaMaisModule`) e o carregamento do `qrCode.png` (no `doacoesModule`) estavam usando caminhos relativos (ex: `../`) que funcionavam localmente, mas quebravam no deploy.

**Correção:**
Os caminhos foram atualizados para serem relativos à raiz do HTML (ex: `./assets/data/projetos.json`), o que é o correto para o GitHub Pages.

Os arquivos `.min.js` correspondentes foram re-minificados e atualizados.